### PR TITLE
Add new head tracking code

### DIFF
--- a/demo/Hud.gd
+++ b/demo/Hud.gd
@@ -1,0 +1,25 @@
+extends Node3D
+
+@export var camera : NodePath
+
+func _ready():
+	var material : StandardMaterial3D = $Display.get_surface_override_material(0)
+	if material:
+		material.albedo_texture = $FPSViewport.get_texture()
+
+func _process(delta):
+	if camera:
+		var camera_node : XRCamera3D = get_node(camera)
+		
+		if camera_node:
+			var t = camera_node.transform
+			var forward : Vector3 = -t.basis.z
+			forward.y = 0.0
+			forward.normalized()
+
+			position = t.origin
+
+			look_at(t.origin + forward)
+
+	var fps = Performance.get_monitor(Performance.TIME_FPS)
+	$FPSViewport/FPS.text = "FPS: " + str(fps)

--- a/demo/Main.gd
+++ b/demo/Main.gd
@@ -1,10 +1,12 @@
 extends Node3D
 
+var xr_interface : XRInterfaceReference
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	print("Interfaces: " + str(XRServer.get_interfaces()))
 	
-	var xr_interface = XRServer.find_interface("XR Reference")
+	xr_interface = XRServer.find_interface("XR Reference")
 	if xr_interface:
 		print("Found " + str(xr_interface.get_name()))
 		print("Capabilities " + str(xr_interface.get_capabilities()))
@@ -19,3 +21,19 @@ func _ready():
 	else:
 		print("Couldn't find interface")
 
+func _input(event):
+	if event is InputEventKey:
+		if event.pressed and event.keycode == KEY_ESCAPE:
+			if xr_interface:
+				xr_interface.use_mouse_for_headtracking = false
+				xr_interface.use_wasd_for_movement = false
+			
+			# Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE)
+	elif event is InputEventMouseButton:
+		if event.pressed:
+			if xr_interface:
+				xr_interface.use_mouse_for_headtracking = true
+				xr_interface.use_wasd_for_movement = true
+			
+			# until we can receive proper input events in our interface we don't have access to the mouse when captured
+			# Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -1,8 +1,18 @@
-[gd_scene load_steps=9 format=3 uid="uid://c4inay0af44y5"]
+[gd_scene load_steps=12 format=3 uid="uid://c4inay0af44y5"]
 
 [ext_resource type="Script" path="res://Main.gd" id="1_86b4p"]
+[ext_resource type="Script" path="res://Hud.gd" id="2_bnd5b"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/blue_grid.tres" id="2_hf54b"]
 [ext_resource type="Material" path="res://assets/wahooney.itch.io/green_grid.tres" id="3_kb4h0"]
+
+[sub_resource type="QuadMesh" id="QuadMesh_pvppo"]
+size = Vector2(0.2, 0.1)
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_ck3l5"]
+resource_local_to_scene = true
+transparency = 1
+no_depth_test = true
+shading_mode = 0
 
 [sub_resource type="PhysicalSkyMaterial" id="PhysicalSkyMaterial_aaq4s"]
 
@@ -26,6 +36,33 @@ script = null
 
 [node name="XRCamera3D" type="XRCamera3D" parent="XROrigin3D"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8, 0)
+script = null
+
+[node name="Hud" type="Node3D" parent="XROrigin3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8, 0)
+script = ExtResource( "2_bnd5b" )
+camera = NodePath("../XRCamera3D")
+
+[node name="FPSViewport" type="SubViewport" parent="XROrigin3D/Hud"]
+disable_3d = true
+transparent_bg = true
+size = Vector2i(300, 150)
+render_target_update_mode = 3
+script = null
+
+[node name="FPS" type="Label" parent="XROrigin3D/Hud/FPSViewport"]
+offset_right = 40.0
+offset_bottom = 23.0
+theme_override_font_sizes/font_size = 72
+text = "FPS: 0"
+structured_text_bidi_override_options = []
+script = null
+
+[node name="Display" type="MeshInstance3D" parent="XROrigin3D/Hud"]
+transform = Transform3D(0.85828, 0, 0.513182, 0, 1, 0, -0.513182, 0, 0.85828, -0.493988, 0.307667, -0.697151)
+mesh = SubResource( "QuadMesh_pvppo" )
+skeleton = NodePath("../../XRCamera3D")
+surface_material_override/0 = SubResource( "StandardMaterial3D_ck3l5" )
 script = null
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]

--- a/src/xr_interface_reference.h
+++ b/src/xr_interface_reference.h
@@ -5,6 +5,7 @@
 
 #include <godot_cpp/core/binder_common.hpp>
 #include <godot_cpp/classes/xr_server.hpp>
+#include <godot_cpp/classes/xr_positional_tracker.hpp>
 
 namespace godot {
 
@@ -28,6 +29,13 @@ private:
 	double k1 = 0.215;
 	double k2 = 0.215;
 	double aspect = 1.0;
+
+	Ref<XRPositionalTracker> head;
+	Transform3D head_transform;
+	bool use_mouse_for_headtracking = false;
+	bool use_wasd_for_movement = false;
+	double angle_x = 0.0;
+	double angle_y = 0.0;
 
 public:
 	// Constants.
@@ -53,6 +61,12 @@ public:
 
 	double get_k2() const;
 	void set_k2(const double p_k2);
+
+	bool get_use_mouse_for_headtracking() const;
+	void set_use_mouse_for_headtracking(bool p_use_mouse_for_headtracking);
+
+	bool get_use_wasd_for_movement() const;
+	void set_use_wasd_for_movement(bool p_use_wasd_for_movement);
 
 	// Functions.
 	virtual StringName _get_name() const override;


### PR DESCRIPTION
This PR implements our head tracking code to show how the tracker system for https://github.com/godotengine/godot/pull/52210 now works. 

You must build Godot using https://github.com/godotengine/godot/pull/52210 and update the `extension_api.json` file in order to test this PR.

I've also added basic mouse and WASD movement into the plugin itself. It moves the HEAD (and thus the XRCamera3d node) to simulate the player actually moving in physical space.  Problem is that we don't actually get proper mouse movement info in the plugin because we can't capture the input events here so it's a little flimsy, but it works. 
Click on the window to enable, press escape to disable, the movement.